### PR TITLE
Include empty properties as empty string instead of 'null'

### DIFF
--- a/.github/workflows/callable-partner-driver.yml
+++ b/.github/workflows/callable-partner-driver.yml
@@ -103,7 +103,7 @@ jobs:
           op item list --format=json --tags partner-testing \
             |  jq -r ".[] | select(.title | test(\"driver: $DRIVER\")) | .id" \
             |  xargs -I {} op item get {} --format=json --vault "Driver Development" \
-            |  jq -r ".fields[] | select(.section.label == \"ENV\") | \"MB_$(echo $DRIVER | tr '[:lower:]' '[:upper:]' | tr '-' '_')_TEST_\\(.label)=\\\"\\(.value)\\\"\"" \
+            |  jq -r ".fields[] | select(.section.label == \"ENV\") | \"MB_$(echo $DRIVER | tr '[:lower:]' '[:upper:]' | tr '-' '_')_TEST_\\(.label)=\\\"\\(.value // \"\")\\\"\"" \
             > driver.env
 
           set -a


### PR DESCRIPTION
Small change for handling drivers that require empty env vars with `tx/db-test-env-var-or-throw`. Without this the env loading would result in `MB_DRIVER_TEST_ADDITIONAL_OPTIONS="null"` instead of the desired`MB_DRIVER_TEST_ADDITIONAL_OPTIONS=""`