### PR TITLE
Add clickhouse password

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,6 +24,8 @@ services:
       }
   clickhouse:
     image: clickhouse/clickhouse-server:latest
+    environment:
+      CLICKHOUSE_PASSWORD: password
     ports:
       - 8123:8123
       - 9000:9000


### PR DESCRIPTION
Related to this, in 1password we now have on the `driver: clickhouse` credential an ENV section. This includes the username `default` and password of `password` which is now being set in the docker compose file of this change.

Here's everything running locally:

```
docker run -p8123:8123 -p9000:9000 -e"CLICKHOUSE_PASSWORD=password" -it --rm clickhouse/clickhouse-server:latest
```

And tests:

```
DRIVERS=clickhouse MB_CLICKHOUSE_TEST_USER=default MB_CLICKHOUSE_TEST_PASSWORD=password clj -X:dev:test:clickhouse :only metabase.driver.clickhouse-test/clickhouse-query-formatting

,,,

LONG TEST in metabase.driver.clickhouse-test/clickhouse-query-formatting
Test took 11.172 seconds seconds to run

1/1   100% [==================================================]  ETA: 00:00

Ran 1 tests in 11.879 seconds
2 assertions, 0 failures, 0 errors.
{:test 1, :pass 2, :fail 0, :error 0, :type :summary, :duration 11878.979667, :parallel 1}
Ran 1 tests in parallel, 0 single-threaded.
Finding and running tests took 22.8 s.
All tests passed.
Running after-run hooks...
```

The docs at https://hub.docker.com/r/clickhouse/clickhouse-server/ say that the default password is empty, but it seems it doesn't allow anyone to connect. So we set it in the docker image and the env of our test runner.

If you are testing locally, you can visit
http://localhost:8123/play?user=default#c2hvdyBkYXRhYmFzZXM= to see an interactive playground. Use default and password in the boxes top right.

Notably, now when we run this in CI, we run the following:

```
❯   op item list --format=json --tags partner-testing \
    |  jq -r ".[] | select(.title | test(\"driver: $DRIVER\")) | .id" \
    |  xargs -I {} op item get {} --format=json --vault "Driver Development" \
    |  jq -r ".fields[] | select(.section.label == \"ENV\") | \"MB_$(echo $DRIVER | tr '[:lower:]' '[:upper:]' | tr '-' '_')_TEST_\\(.label)=\\\"\\(.value // \"\")\\\"\"" \
    > driver.env

❯ cat driver.env
MB_CLICKHOUSE_TEST_password="password"
MB_CLICKHOUSE_TEST_username="default"
```

So i'm hopeful that clickhouse will be green now