### PR TITLE
Bump node version

### DIFF
--- a/.github/workflows/callable-partner-driver.yml
+++ b/.github/workflows/callable-partner-driver.yml
@@ -73,7 +73,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v2
         with:
-          node-version: "18"
+          node-version: "22"
           cache: "yarn"
           cache-dependency-path: ./metabase/yarn.lock
 

--- a/.github/workflows/check-driver-urls.yml
+++ b/.github/workflows/check-driver-urls.yml
@@ -15,7 +15,7 @@ jobs:
       uses: actions/checkout@v4
     - uses: actions/setup-node@v4
       with:
-        node-version: lts/Iron # 20.x.x
+        node-version: "22"
     - run: npm install yaml
     - name: parse drivers registry
       uses: actions/github-script@v7
@@ -85,4 +85,3 @@ jobs:
 
           console.log(`\n\n✅  Successfully fetched all urls`);
           process.exit(0);
-


### PR DESCRIPTION
getting errors that our version is too low now

![image](https://github.com/user-attachments/assets/e7faa53c-0d46-4c0d-b322-2a680474bad1)

bumping in both places and hope for the best