### PR TITLE
Bump materialize driver version to 1.4.2

### DIFF
--- a/registry.yaml
+++ b/registry.yaml
@@ -34,13 +34,14 @@ drivers:
   - name: materialize
     homepage: https://github.com/MaterializeInc/metabase-materialize-driver
     versions:
-      default: https://github.com/MaterializeInc/metabase-materialize-driver/releases/download/v1.4.0/materialize.metabase-driver.jar
+      default: https://github.com/MaterializeInc/metabase-materialize-driver/releases/download/v1.4.2/materialize.metabase-driver.jar
+      52: https://github.com/MaterializeInc/metabase-materialize-driver/releases/download/v1.4.2/materialize.metabase-driver.jar
       50: https://github.com/MaterializeInc/metabase-materialize-driver/releases/download/v1.2.1/materialize.metabase-driver.jar
     test:
       docker: true
       repo: MaterializeInc/metabase-materialize-driver
       refs:
-        default: v1.4.0
+        default: v1.4.2
   - name: starburst
     homepage: https://github.com/starburstdata/metabase-driver
     versions:


### PR DESCRIPTION
Bump materialize driver version to 1.4.2 to include changes they made for failing tests in v52. Should also fix the `Could not locate metabase/public_settings/premium_features ... on classpath` error in v53. 